### PR TITLE
Add Travis CI build badge to GH landing page

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # opendaylight-bot
 
+[![Build Status](https://travis-ci.org/vorburger/opendaylight-bot.svg?branch=master)](https://travis-ci.org/vorburger/opendaylight-bot)
+
 The ODL Bot is a software delivery automation tool. It originated in the OpenDaylight.org FLOSS SDN community,
 but could be used by other open-source communities (and for in-house proprietary code) as well.  Its features are:
 


### PR DESCRIPTION
The README acts as a landing page so we can add the Travis CI build
badge here to report if the branch is currently in a good state.

Signed-off-by: Thanh Ha <zxiiro@linux.com>