### PR TITLE
Adding Jenkins-rest to start Jobs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,4 +21,11 @@
     <module>bot</module>
     <module>spring</module>
   </modules>
+  
+  <dependency>
+  <groupId>com.cdancy</groupId>
+  <artifactId>jenkins-rest</artifactId>
+  <version>0.0.10</version>
+ </dependency>
+  
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -22,10 +22,12 @@
     <module>spring</module>
   </modules>
   
+ <dependencies>
   <dependency>
   <groupId>com.cdancy</groupId>
   <artifactId>jenkins-rest</artifactId>
   <version>0.0.10</version>
  </dependency>
+ </dependencies>
   
 </project>


### PR DESCRIPTION
Preferred `jenkins-rest` due to https://github.com/vorburger/opendaylight-bot/issues/8#issuecomment-389379749 

Will shift to the `java-client-api` if the choice is otherwise